### PR TITLE
Fix default message font color

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const AlertTemplate = ({ message, options, style, close }) => {
       {options.type === 'info' && <InfoIcon />}
       {options.type === 'success' && <SuccessIcon />}
       {options.type === 'error' && <ErrorIcon />}
-      <span style={{ flex: 2 }}>{message}</span>
+      <span style={{ flex: 2, color: 'white' }}>{message}</span>
       <button onClick={close} style={buttonStyle}>
         <CloseIcon />
       </button>


### PR DESCRIPTION
## Summary
By default, the alert has the same color for the message and the background. This pr sets the default font color to white.

See screenshots below: 
Default:
<img width="311" alt="screen shot 2018-02-26 at 7 44 34 pm" src="https://user-images.githubusercontent.com/1928544/36700106-827c8a08-1b2d-11e8-948d-c3d51a349721.png">
Selected Text:
<img width="311" alt="screen shot 2018-02-26 at 7 44 37 pm" src="https://user-images.githubusercontent.com/1928544/36700107-82a27e8e-1b2d-11e8-9384-760de98221de.png">


