### PR TITLE
Expose icons as named exports for consumers of package

### DIFF
--- a/src/AlertTemplate.js
+++ b/src/AlertTemplate.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { InfoIcon, SuccessIcon, ErrorIcon, CloseIcon } from './icons'
+
+const alertStyle = {
+  backgroundColor: '#151515',
+  color: 'white',
+  padding: '10px',
+  textTransform: 'uppercase',
+  borderRadius: '3px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  boxShadow: '0px 2px 2px 2px rgba(0, 0, 0, 0.03)',
+  fontFamily: 'Arial',
+  width: '300px',
+  boxSizing: 'border-box'
+}
+
+const buttonStyle = {
+  marginLeft: '20px',
+  border: 'none',
+  backgroundColor: 'transparent',
+  cursor: 'pointer',
+  color: '#FFFFFF'
+}
+
+const AlertTemplate = ({ message, options, style, close }) => {
+  return (
+    <div style={{ ...alertStyle, ...style }}>
+      {options.type === 'info' && <InfoIcon />}
+      {options.type === 'success' && <SuccessIcon />}
+      {options.type === 'error' && <ErrorIcon />}
+      <span style={{ flex: 2 }}>{message}</span>
+      <button onClick={close} style={buttonStyle}>
+        <CloseIcon />
+      </button>
+    </div>
+  )
+}
+
+export default AlertTemplate

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -1,0 +1,6 @@
+import InfoIcon from './InfoIcon'
+import SuccessIcon from './SuccessIcon'
+import ErrorIcon from './ErrorIcon'
+import CloseIcon from './CloseIcon'
+
+export { InfoIcon, SuccessIcon, ErrorIcon, CloseIcon, BaseIcon }

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -1,6 +1,7 @@
+import BaseIcon from './BaseIcon'
 import InfoIcon from './InfoIcon'
 import SuccessIcon from './SuccessIcon'
 import ErrorIcon from './ErrorIcon'
 import CloseIcon from './CloseIcon'
 
-export { InfoIcon, SuccessIcon, ErrorIcon, CloseIcon, BaseIcon }
+export { BaseIcon, InfoIcon, SuccessIcon, ErrorIcon, CloseIcon }

--- a/src/index.js
+++ b/src/index.js
@@ -1,44 +1,5 @@
-import React from 'react'
-import InfoIcon from './icons/InfoIcon'
-import SuccessIcon from './icons/SuccessIcon'
-import ErrorIcon from './icons/ErrorIcon'
-import CloseIcon from './icons/CloseIcon'
+import * as Icons from './icons'
+import AlertTemplate from './AlertTemplate'
 
-const alertStyle = {
-  backgroundColor: '#151515',
-  color: 'white',
-  padding: '10px',
-  textTransform: 'uppercase',
-  borderRadius: '3px',
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  boxShadow: '0px 2px 2px 2px rgba(0, 0, 0, 0.03)',
-  fontFamily: 'Arial',
-  width: '300px',
-  boxSizing: 'border-box'
-}
-
-const buttonStyle = {
-  marginLeft: '20px',
-  border: 'none',
-  backgroundColor: 'transparent',
-  cursor: 'pointer',
-  color: '#FFFFFF'
-}
-
-const AlertTemplate = ({ message, options, style, close }) => {
-  return (
-    <div style={{ ...alertStyle, ...style }}>
-      {options.type === 'info' && <InfoIcon />}
-      {options.type === 'success' && <SuccessIcon />}
-      {options.type === 'error' && <ErrorIcon />}
-      <span style={{ flex: 2 }}>{message}</span>
-      <button onClick={close} style={buttonStyle}>
-        <CloseIcon />
-      </button>
-    </div>
-  )
-}
-
+export { Icons }
 export default AlertTemplate

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,2 @@
-import * as Icons from './icons'
-import AlertTemplate from './AlertTemplate'
-
-export { Icons }
-export default AlertTemplate
+export * from './icons'
+export { default } from './AlertTemplate'


### PR DESCRIPTION
I quite like the Icons in this package. I wanted to create my own custom AlertTemplate, but still make use of the icons without doing a copy paste of code from this repository.

This pull request does a small refactor which bunches up all the icons as named exports from an index file in the 'src/icons' directory and moves the AlertTemplate to its own file. The 'src/index' file is then changed to be the entry point for the build, and is where AlertTemplate is exported as default, and the icons are exported as named exports.